### PR TITLE
Amputate Links

### DIFF
--- a/app/src/main/java/me/zhanghai/android/untracker/BuiltinRuleList.kt
+++ b/app/src/main/java/me/zhanghai/android/untracker/BuiltinRuleList.kt
@@ -96,6 +96,20 @@ val BuiltinRuleList =
                             .trimIndent()
                 ),
                 Rule(
+                    id = "26a2a812-cb45-44ad-ba2d-a595d70c50d5",
+                    name = "Amputate - Path",
+                    description = "Remove Google AMP paths\nexample.com/amp/index ==> example.com/index\nexample.com/index.amp ==> example.com/index)",
+                    enabled = true,
+                    script =
+                        """
+                            if ($.matches(url, '.*', '.*amp.*')) {
+                                const path = $.getEncodedPath(url).replace(/[./]amp(?!\w)/, '');
+                                return $.setEncodedPath(url, path);
+                            }
+                        """
+                            .trimIndent()
+                ),
+                Rule(
                     id = "7edf803f-c165-46ef-b4d1-b8cbc6b5cb65",
                     name = "Bilibili",
                     description = "Remove tracking for Bilibili",

--- a/app/src/main/java/me/zhanghai/android/untracker/BuiltinRuleList.kt
+++ b/app/src/main/java/me/zhanghai/android/untracker/BuiltinRuleList.kt
@@ -82,6 +82,20 @@ val BuiltinRuleList =
                             .trimIndent()
                 ),
                 Rule(
+                    id = "78a216da-ed3e-4c7b-8eab-6094ac3d7c56",
+                    name = "Amputate - Host",
+                    description = "Remove Google AMP subdomains\namp.example.com ==> example.com",
+                    enabled = true,
+                    script =
+                        """
+                            if ($.matches(url, '(.+[.])?amp[.].+')) {
+                                const host = $.getHost(url).replace(/(?<!\w)amp[.]/, '');
+                                return $.setHost(url, host);
+                            }
+                        """
+                            .trimIndent()
+                ),
+                Rule(
                     id = "7edf803f-c165-46ef-b4d1-b8cbc6b5cb65",
                     name = "Bilibili",
                     description = "Remove tracking for Bilibili",


### PR DESCRIPTION
From [issue 1](https://github.com/zhanghai/Untracker/issues/1), this pull request adds two simple rules that convert three different types of Google AMP links to their canonical equivalent. There may be AMP links that take other forms not covered by these rules.

> [!NOTE]
> > Google AMP (Accelerated Mobile Pages) is harmful to the free and open web for [a variety of reasons](https://old.reddit.com/r/AmputatorBot/comments/ehrq3z/why_did_i_build_amputatorbot/) that are beyond the scope of this discussion. Relevant to this app, it enables both the publisher _and_ Google to spy on readers instead of just the publisher. It also misrepresents who is serving you content in the URL bar.

There is no straightforward way I see to create a single rule covering all three of these link types using the interface exposed by Untracker, at least without running this rule on _all_ links instead of just AMP links.

## Amputate - Host
This rule converts Google AMP links of the subdomain form...
```
https://amp.example.com/some/path/news-article.html
```
...to their canonical form.
```
https://example.com/some/path/news-article.html
```
Here is my rule code.
```js
if ($.matches(url, '(.+[.])?amp[.].+')) {
    const host = $.getHost(url).replace(/(?<!\w)amp[.]/, '');
    return $.setHost(url, host);
}
```

## Amputate - Path
This rule amputates links using the path form...
```
https://example.com/amp/some/path/news-article.html
```
...or the file extension form of Google AMP...
```
https://example.com/some/path/news-article.html.amp
```
...to their canonical form.
```
https://example.com/some/path/news-article.html
```
Here is my rule code.
```js
if ($.matches(url, '.*', '.*amp.*')) {
    const path = $.getEncodedPath(url).replace(/[./]amp(?!\w)/, '');
    return $.setEncodedPath(url, path);
}
```

### Tests
I tested my changes against Untracker `v1.0.3 (4)` from [F-Droid](https://f-droid.org/packages/me.zhanghai.android.untracker).

**1. -** AMP subdomain is removed.
```
https://amp.example.com/some/path/news-article.html
```
![1](https://github.com/zhanghai/Untracker/assets/34947245/18d54aaa-64d8-425e-b363-c56e5ed9ea2a)

**2. -** Normal subdomains are preserved.
```
https://amp.news.example.com/some/path/news-article.html
```
![2](https://github.com/zhanghai/Untracker/assets/34947245/274aa1d4-27b8-4bf6-afc7-bdebbeb7a583)

**3. -** Non-AMP subdomains are not matched.
```
https://damp.example.com/some/path/news-article.html
```
![3](https://github.com/zhanghai/Untracker/assets/34947245/be89b90a-f6da-445a-baf7-d8957de3bac1)

**4. -** Non-AMP subdomains are not matched.
```
https://amperes.example.com/some/path/news-article.html
```
![4](https://github.com/zhanghai/Untracker/assets/34947245/545c11f0-84ec-4173-b7cb-dac92d3aca7a)

**5. -** AMP paths are removed.
```
https://example.com/amp/some/path/news-article.html
```
![5](https://github.com/zhanghai/Untracker/assets/34947245/8b6bebdb-0113-4be4-9474-af03c9f4eee9)

**6. -** Non-AMP paths are not matched.
```
https://example.com/damp/some/path/news-article.html
```
![6](https://github.com/zhanghai/Untracker/assets/34947245/5eb2d46b-da03-4b9f-8c04-bdd63c137ce3)

**7. -** Non-AMP paths are not matched.
```
https://example.com/ampere/some/path/news-article.html
```
![7](https://github.com/zhanghai/Untracker/assets/34947245/4efa2ee8-d6ce-4788-a886-870f6a31ea81)

**8. -** AMP file extensions are removed.
```
https://example.com/some/path/news-article.html.amp
```
![8](https://github.com/zhanghai/Untracker/assets/34947245/ca69d8a8-c553-4de8-a0ea-ffca236360de)

**9. -** AMP file extensions are removed.
```
https://example.com/some/path/news-article.amp.html
```
![9](https://github.com/zhanghai/Untracker/assets/34947245/e535a964-1a93-45ca-8403-68b92ec61dcf)

---
- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR