### PR TITLE
feat(i18n): 为预置规则的显示名称和描述添加中文本地化支持并优化规则列表显示

### DIFF
--- a/app/src/main/java/me/zhanghai/android/untracker/BuiltinRuleList.kt
+++ b/app/src/main/java/me/zhanghai/android/untracker/BuiltinRuleList.kt
@@ -16,6 +16,7 @@
 
 package me.zhanghai.android.untracker
 
+import me.zhanghai.android.untracker.model.I18nStrings
 import me.zhanghai.android.untracker.model.Rule
 import me.zhanghai.android.untracker.model.RuleList
 
@@ -37,7 +38,11 @@ val BuiltinRuleList =
                                 return $.getQueryParameter(url, 'target');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "常见重定向",
+                        localeDescription = "删除常见重定向",
+                    )
                 ),
                 Rule(
                     id = "a925a9f0-84bb-46eb-bea2-1bded576d8c9",
@@ -72,20 +77,32 @@ val BuiltinRuleList =
                             }
                             return url;
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "常见短链",
+                        localeDescription = "展开常见短链",
+                    )
                 ),
                 Rule(
                     id = "19d74b86-5ac0-4218-8ec8-ee89e4d237f1",
                     name = "Common analytics",
                     description = "Remove tracking for common analytics",
-                    script = """return $.removeQueryParameters(url, '[isu]tm_.*|ref');"""
+                    script = """return $.removeQueryParameters(url, '[isu]tm_.*|ref');""",
+                    zhCNValue = I18nStrings(
+                        localeName = "常见统计",
+                        localeDescription = "删除常见统计",
+                    )
                 ),
                 Rule(
                     id = "87af5849-1e81-42bd-984e-e30a1ec08db4",
                     name = "Common ads",
                     description = "Remove tracking for common ads",
                     script =
-                        """return $.removeQueryParameters(url, '(fb|g|tt|wicked|y)cl(id|source|src)|[gw]braid');"""
+                        """return $.removeQueryParameters(url, '(fb|g|tt|wicked|y)cl(id|source|src)|[gw]braid');""",
+                    zhCNValue = I18nStrings(
+                        localeName = "常见广告",
+                        localeDescription = "删除常见广告",
+                    )
                 ),
                 Rule(
                     id = "3805dd66-b341-4da3-b5ba-f3acc69ed189",
@@ -103,7 +120,11 @@ val BuiltinRuleList =
                                 return url;
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "Amazon 亚马逊",
+                        localeDescription = "删除亚马逊跟踪",
+                    )
                 ),
                 Rule(
                     id = "7edf803f-c165-46ef-b4d1-b8cbc6b5cb65",
@@ -116,7 +137,11 @@ val BuiltinRuleList =
                                 return $.removeQueryParameters(url, 'p', '1');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "哔哩哔哩",
+                        localeDescription = "删除哔哩哔哩跟踪",
+                    )
                 ),
                 Rule(
                     id = "db094a08-e3c4-4bd9-aa98-16df86237f6d",
@@ -146,7 +171,11 @@ val BuiltinRuleList =
                             }
                         """
                             .trimIndent(),
-                    enabled = false
+                    enabled = false,
+                    zhCNValue = I18nStrings(
+                        localeName = "哔哩哔哩 BV",
+                        localeDescription = "将哔哩哔哩 BV 号转换为 AV 号",
+                    )
                 ),
                 Rule(
                     id = "ad21dada-9f09-4adf-9db2-d1575ca8b4a4",
@@ -158,7 +187,11 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "豆瓣",
+                        localeDescription = "删除豆瓣跟踪",
+                    )
                 ),
                 Rule(
                     id = "c112da1e-384e-42e2-b110-ce6d8edbfe7a",
@@ -170,7 +203,11 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "抖音",
+                        localeDescription = "删除抖音跟踪",
+                    )
                 ),
                 Rule(
                     id = "926090a8-a98a-4168-b6a1-b6b801c76955",
@@ -182,7 +219,11 @@ val BuiltinRuleList =
                                 return $.retainQueryParameters(url, 'q|tbm');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "Google 搜索",
+                        localeDescription = "删除 Google 搜索跟踪",
+                    )
                 ),
                 Rule(
                     id = "bcd9fcb8-bf1c-41f8-b18d-b248507e43c7",
@@ -194,19 +235,27 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "Instagram",
+                        localeDescription = "删除 Instagram 跟踪",
+                    )
                 ),
                 Rule(
                     id = "c68c4cbf-9ae5-41f6-89ba-6e3f31ffb6a2",
-                    name = "JD",
-                    description = "Remove tracking for JD",
+                    name = "JD.com",
+                    description = "Remove tracking for JD.com",
                     script =
                         """
                             if ($.matches(url, '.+\\.jd\\.com')) {
                                 return $.retainQueryParameters(url, 'id|shopId|skuIds|suitId|wareId');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "京东",
+                        localeDescription = "删除京东跟踪",
+                    )
                 ),
                 Rule(
                     id = "1d0c3aae-c456-4352-972a-8b0b0f6e36c1",
@@ -218,7 +267,11 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "快手",
+                        localeDescription = "删除快手跟踪",
+                    )
                 ),
                 Rule(
                     id = "c722500a-17c8-462a-8a74-0c15fefe1b3e",
@@ -230,7 +283,11 @@ val BuiltinRuleList =
                                 return $.retainQueryParameters(url, 'id');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "网易云音乐",
+                        localeDescription = "删除网易云音乐跟踪",
+                    )
                 ),
                 Rule(
                     id = "465d579e-bc3b-4c5b-bac3-9b84c67c7554",
@@ -242,7 +299,11 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "Netflix",
+                        localeDescription = "删除 Netflix 跟踪",
+                    )
                 ),
                 Rule(
                     id = "21065dad-2c4c-4431-acd7-32825e831c32",
@@ -260,7 +321,11 @@ val BuiltinRuleList =
                                 return url;
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "Pinterest",
+                        localeDescription = "删除 Pinterest 跟踪",
+                    )
                 ),
                 Rule(
                     id = "67035e8c-9418-47e7-9f62-56cd30666772",
@@ -272,7 +337,11 @@ val BuiltinRuleList =
                                 return $.retainQueryParameters(url, 'context');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "Reddit",
+                        localeDescription = "删除 Reddit 跟踪",
+                    )
                 ),
                 Rule(
                     id = "55662cf5-b43e-491a-b72b-adc1111b8583",
@@ -287,7 +356,11 @@ val BuiltinRuleList =
                                 return $.setEncodedPath($.setHost(url, 'old.reddit.com'), '/video' + $.getEncodedPath(url));
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "旧 Reddit",
+                        localeDescription = "使用旧 Reddit 代替新 Reddit",
+                    )
                 ),
                 Rule(
                     id = "4244faaa-b50e-47f1-87a5-ac994c32b94f",
@@ -299,7 +372,11 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "什么值得买",
+                        localeDescription = "删除什么值得买跟踪",
+                    )
                 ),
                 Rule(
                     id = "8cbda6f2-d71d-4ee3-8ee0-05b245861c0d",
@@ -311,7 +388,11 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "Spotify",
+                        localeDescription = "删除 Spotify 跟踪",
+                    )
                 ),
                 Rule(
                     id = "5ed9b3ef-f4de-44c8-bd34-5c8da6e330af",
@@ -323,7 +404,11 @@ val BuiltinRuleList =
                                 return $.setEncodedPath(url, $.getEncodedPath(url).replace(/\/[0-9]+\/?$/i, ''));
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "Stack Exchange",
+                        localeDescription = "删除 Stack Exchange 跟踪",
+                    )
                 ),
                 Rule(
                     id = "9cb803b3-ed57-46ad-b604-8adb8c515c07",
@@ -335,7 +420,11 @@ val BuiltinRuleList =
                                 return $.retainQueryParameters(url, 'id');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "淘宝",
+                        localeDescription = "删除淘宝和天猫跟踪",
+                    )
                 ),
                 Rule(
                     id = "8420b788-c6ee-46a6-ab3b-da04d6299beb",
@@ -347,7 +436,11 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "TikTok",
+                        localeDescription = "删除 TikTok 跟踪",
+                    )
                 ),
                 Rule(
                     id = "7a6a2ddb-a0a4-43fe-a97f-7cb74cd29ad5",
@@ -359,19 +452,27 @@ val BuiltinRuleList =
                                 return $.setEncodedQuery(url, null);
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "X",
+                        localeDescription = "删除 X（原 Twitter）跟踪",
+                    )
                 ),
                 Rule(
                     id = "84c837db-f1c0-4738-b0ea-0f3d091885d7",
-                    name = "Xiaohongshu",
-                    description = "Remove tracking for Xiaohongshu",
+                    name = "rednote",
+                    description = "Remove tracking for rednote",
                     script =
                         """
                             if ($.matches(url, '.+\\.xiaohongshu\\.com')) {
                                 return $.retainQueryParameters(url, 'xsec_token');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "小红书",
+                        localeDescription = "删除小红书跟踪",
+                    )
                 ),
                 Rule(
                     id = "88a68140-7653-4923-991d-19d1a98cd5e3",
@@ -383,7 +484,11 @@ val BuiltinRuleList =
                                 return $.retainQueryParameters(url, 'index|list|t|v');
                             }
                         """
-                            .trimIndent()
+                            .trimIndent(),
+                    zhCNValue = I18nStrings(
+                        localeName = "YouTube",
+                        localeDescription = "删除 YouTube 跟踪",
+                    )
                 )
             )
     )

--- a/app/src/main/java/me/zhanghai/android/untracker/Untracker.kt
+++ b/app/src/main/java/me/zhanghai/android/untracker/Untracker.kt
@@ -22,8 +22,6 @@ import android.text.util.Linkify
 import androidx.annotation.Keep
 import androidx.core.util.PatternsCompat
 import app.cash.quickjs.QuickJs
-import java.io.IOException
-import java.net.URI
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -39,6 +37,8 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.net.URI
 
 object Untracker {
     fun untrack(text: String): String {

--- a/app/src/main/java/me/zhanghai/android/untracker/model/Rule.kt
+++ b/app/src/main/java/me/zhanghai/android/untracker/model/Rule.kt
@@ -17,8 +17,8 @@
 package me.zhanghai.android.untracker.model
 
 import androidx.compose.runtime.Immutable
-import java.util.UUID
 import kotlinx.serialization.Serializable
+import java.util.UUID
 
 @Immutable
 @Serializable
@@ -27,5 +27,12 @@ data class Rule(
     val name: String = "",
     val description: String = "",
     val script: String = "",
-    val enabled: Boolean = true
+    val enabled: Boolean = true,
+    val zhCNValue: I18nStrings? = null
+)
+
+@Serializable
+data class I18nStrings(
+    val localeName: String? = null,
+    val localeDescription: String? = null,
 )

--- a/app/src/main/java/me/zhanghai/android/untracker/util/SharedPreferencesExtensions.kt
+++ b/app/src/main/java/me/zhanghai/android/untracker/util/SharedPreferencesExtensions.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 inline fun <reified T> SharedPreferences.getObject(key: String): T? {

--- a/app/src/main/java/me/zhanghai/android/untracker/util/Transitions.kt
+++ b/app/src/main/java/me/zhanghai/android/untracker/util/Transitions.kt
@@ -24,9 +24,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import kotlin.math.roundToInt
 import me.zhanghai.android.untracker.ui.token.Durations
 import me.zhanghai.android.untracker.ui.token.Easings
+import kotlin.math.roundToInt
 
 // See also android:Animation.Activity .
 // Modified to be fade through to account for missing expand transition.

--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -19,6 +19,12 @@
 <resources>
     <style name="Platform.Theme.Untracker.V29" parent="Platform.Theme.Untracker.V27">
         <item name="android:forceDarkAllowed">false</item>
+
+        <!--
+            Without this line of code, Android will probably mask the system bar
+            不加这行代码的话，Android 可能会在系统栏加遮罩（荣耀机型复现）
+        -->
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
     <style name="Platform.Theme.Untracker" parent="Platform.Theme.Untracker.V29" />
 </resources>


### PR DESCRIPTION
- 在 Rule 模型中添加 zhCNValue 字段，用于存储中文本地化信息
- 更新 BuiltinRuleList，为每个规则添加中文名称和描述
- 修改 RuleList 组件，根据设备语言动态显示中文或英文
- 优化主题配置，解决荣耀设备手势导航提示条背后区域被 Android 添加遮罩的显示问题

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

备注：

1. 小红书官方英文名称已更改为“rednote”（全小写）
2. 京东英文“JD”更改为“JD.com”更合适