### PR TITLE
fix(ui): 优化主题配置，解决荣耀设备手势导航提示条背后区域被 Android 添加遮罩的显示问题

### DIFF
--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -18,13 +18,9 @@
 
 <resources>
     <style name="Platform.Theme.Untracker.V29" parent="Platform.Theme.Untracker.V27">
-        <item name="android:forceDarkAllowed">false</item>
-
-        <!--
-            Without this line of code, Android will probably mask the system bar
-            不加这行代码的话，Android 可能会在系统栏加遮罩（荣耀机型复现）
-        -->
         <item name="android:enforceNavigationBarContrast">false</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:forceDarkAllowed">false</item>
     </style>
     <style name="Platform.Theme.Untracker" parent="Platform.Theme.Untracker.V29" />
 </resources>

--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -19,6 +19,12 @@
 <resources>
     <style name="Platform.Theme.Untracker.V29" parent="Platform.Theme.Untracker.V27">
         <item name="android:forceDarkAllowed">false</item>
+
+        <!--
+            Without this line of code, Android will probably mask the system bar
+            不加这行代码的话，Android 可能会在系统栏加遮罩（荣耀机型复现）
+        -->
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
     <style name="Platform.Theme.Untracker" parent="Platform.Theme.Untracker.V29" />
 </resources>


### PR DESCRIPTION
- 优化主题配置，解决荣耀设备手势导航提示条背后区域被 Android 添加遮罩的显示问题

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

默认情况下 Android 系统会自动确保导航栏有足够的对比度，因此会自动在 Android 认为对比度不明显的情况下在系统导航栏背后区域添加遮罩。此更改为该应用强制关闭了该特性。

![Collage_20250618_114609655.jpg](https://github.com/user-attachments/assets/2c94f656-ced4-49c2-afff-4725cf094845)

